### PR TITLE
Bug fix for ACE grenade throw when safety enabled

### DIFF
--- a/err/safety.sqf
+++ b/err/safety.sqf
@@ -26,13 +26,13 @@ err_safety_fnc_playerInit = {
 	};
 
 	// Destroy all nearby fired rounds (or grenades) while safety is enabled.
-	private _ehHandle = player addEventHandler ["FiredMan", {
-		params ["_unit", "_weapon", "_muzzle", "_mode", "_ammo", "_magazine", "_projectile", "_gunner"];
+	private _ehHandle = ["ace_firedPlayer", {
+		params ["_unit", "_weapon", "_muzzle", "_mode", "_ammo", "_magazine", "_projectile"];
 
 		deleteVehicle _projectile;
 
 		[format["%1 fired a %2 during safestart.", name _unit, _projectile]] remoteExec ["err_main_fnc_systemChatIfAdmin", 0];
-	}];
+	}] call CBA_fnc_addEventHandler;
 
 	// Wait until safety is disabled.
 	private _timeInSafety = 0;
@@ -43,7 +43,7 @@ err_safety_fnc_playerInit = {
 			lineBreak,
 			parseText format["<t font='RobotoCondensed' align='center' valign='bottom'>Briefing has lasted <t color='#F2E205'>%1</t> minutes.</t>", floor(_timeInSafety / 60)]
 		];
-		
+
 		sleep 1;
 		_timeInSafety = _timeInSafety + 1;
 
@@ -51,7 +51,7 @@ err_safety_fnc_playerInit = {
 	};
 
 	// Disable the event handler.
-	player removeEventHandler ["FiredMan", _ehHandle];
+	["ace_firedPlayer", _ehHandle] call CBA_fnc_removeEventHandler;
 
 	hint composeText [
 		parseText "<t font='RobotoCondensed' align='center' size='2'>Safety has been <t color='#F20505'>disabled</t></t>"


### PR DESCRIPTION
Tested it local and on server with others, seems to work just fine.

Just moved over to the ACE FiredPlayer event where they detect ACE interactions as well as standard BI. 
Needed to switch over to `CBA_fnc_addEventHandler` / `CBA_fnc_removeEventHandler` to pick up the new ace event.